### PR TITLE
Add Support for Passing Contentful Environment Directly to Migrator Class

### DIFF
--- a/lib/contentful_migrations/migrator.rb
+++ b/lib/contentful_migrations/migrator.rb
@@ -22,21 +22,23 @@ module ContentfulMigrations
       new(parse_options(args)).pending
     end
 
-    attr_reader :migrations_path, :access_token, :space_id, :client, :space,
+    attr_reader :migrations_path, :access_token, :space_id, :client, :space, :env_id,
                 :migration_content_type_name, :logger
 
     def initialize(migrations_path:,
                    access_token:,
                    space_id:,
                    migration_content_type_name:,
-                   logger:)
+                   logger:,
+                   env_id: nil)
       @migrations_path = migrations_path
       @access_token = access_token
       @logger = logger
       @space_id = space_id
       @migration_content_type_name = migration_content_type_name
       @client = Contentful::Management::Client.new(access_token)
-      @space = @client.environments(space_id).find(ENV['CONTENTFUL_ENV'] || 'master')
+      @env_id = env_id || ENV['CONTENTFUL_ENV'] || 'master'
+      @space = @client.environments(space_id).find(@env_id)
       validate_options
     end
 

--- a/spec/lib/contentful_migrations/migrator_spec.rb
+++ b/spec/lib/contentful_migrations/migrator_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe ContentfulMigrations::Migrator do
       access_token: 'access_token',
       space_id: 'space_id',
       migration_content_type_name: ContentfulMigrations::MigrationContentType::DEFAULT_MIGRATION_CONTENT_TYPE,
-      logger: logger }
+      logger: logger,
+      env_id: 'master' }
   end
 
   describe '#initialize' do
@@ -60,6 +61,7 @@ RSpec.describe ContentfulMigrations::Migrator do
       expect(migrator.access_token).to eq('access_token')
       expect(migrator.space_id).to eq('space_id')
       expect(migrator.migration_content_type_name).to eq('migrations')
+      expect(migrator.env_id).to eq('master')
     end
     it 'raises error when invalid path' do
       expect do


### PR DESCRIPTION
This PR updates Migrator so that we can define a specific environment during script invocation, vs. relying on environmental constants and/or defaulting to `master`. 